### PR TITLE
Remove unnecessary complications

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
 				<div class="field">
 					<label for="separator">Separator</label>
-					<input type="text" id="separator" data-option="separator" value=" " /> <small>(Multiple values will be used randomly, try <strong>*&amp;^%$#!</strong> )</small>
+					<input type="text" id="separator" data-option="separator" value=" " size="1"/>
 				</div>
 
 				<div class="field cbx">

--- a/index.html
+++ b/index.html
@@ -40,8 +40,6 @@
 				<div class="field">
 					<label for="min-words">Words</label>
 					<select id="min-words" data-option="minWords">
-						<option value="2">2</option>
-						<option value="3">3</option>
 						<option value="4" selected="selected">4</option>
 						<option value="5">5</option>
 						<option value="6">6</option>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 			<div class="fieldset">
 				<legend>Options</legend>
 				<div class="field">
-					<label for="min-words">Min words</label>
+					<label for="min-words">Words</label>
 					<select id="min-words" data-option="minWords">
 						<option value="2">2</option>
 						<option value="3">3</option>
@@ -52,19 +52,6 @@
 					</select>
 
 
-				</div>
-				<div class="field">
-					<label for="min-length">Min Length</label>
-					<select id="min-length" data-option="minLength">
-						<option value="10">10</option>
-						<option value="15">15</option>
-						<option value="20" selected="selected">20</option>
-						<option value="25">25</option>
-						<option value="30">30</option>
-						<option value="35">35</option>
-						<option value="40">40</option>
-					</select>
-					<small>(including the separator)</small>
 				</div>
 
 				<div class="field">

--- a/index.html
+++ b/index.html
@@ -78,11 +78,6 @@
 				</div>
 
 				<div class="field cbx">
-					<input type="checkbox" data-option="appendNumbers" id="append-numbers" />
-					<label for="append-numbers">Append random number to the end (0 - 9)</label>
-				</div>
-
-				<div class="field cbx">
 					<input type="checkbox" data-option="saveOptions" id="save-options" />
 					<label for="save-options"><strong>Save these options.*</strong></label>
 				</div>

--- a/js/main.js
+++ b/js/main.js
@@ -19,8 +19,7 @@ function CorrectHorseBatteryStaple() {
 	 * @type {Object}
 	 */
 	this.config = {
-		storageKey:       "CHBSOptions",
-		randomNumberPool: 10
+		storageKey:       "CHBSOptions"
 	};
 
 	this.data = [];
@@ -51,7 +50,6 @@ function CorrectHorseBatteryStaple() {
 		minLength:     10,
 		firstUpper:    true,
 		minWords:      3,
-		appendNumbers: true,
 		separator:     "-"
 	};
 
@@ -305,11 +303,6 @@ function CorrectHorseBatteryStaple() {
 			symbol = "";
 
 		wordsLen = words.length;
-
-		if ( this.options.appendNumbers ) {
-			words.push(this.getUniformRandomInteger(0, this.config.randomNumberPool));
-			wordsLen = words.length;
-		}
 
 		for ( i = 0; i < wordsLen; i++ ) {
 

--- a/js/main.js
+++ b/js/main.js
@@ -48,7 +48,7 @@ function CorrectHorseBatteryStaple() {
 	// Default options
 	this.defaults = {
 		firstUpper:    true,
-		minWords:      3,
+		minWords:      4,
 		separator:     "-"
 	};
 

--- a/js/main.js
+++ b/js/main.js
@@ -47,7 +47,6 @@ function CorrectHorseBatteryStaple() {
 
 	// Default options
 	this.defaults = {
-		minLength:     10,
 		firstUpper:    true,
 		minWords:      3,
 		separator:     "-"
@@ -251,7 +250,6 @@ function CorrectHorseBatteryStaple() {
 		this.words = [];
 
 		this.options.minWords = parseInt(this.options.minWords, 10) || this.defaults.minWords;
-		this.options.minLength = parseInt(this.options.minLength, 10) || this.defaults.minLength;
 
 		this.fullPassword = this.getWords();
 
@@ -278,15 +276,9 @@ function CorrectHorseBatteryStaple() {
 		//generate a full string to test against min length
 		fullword = this.words.join(this.options.separator.substring(0, 1) || "");
 
-		//recurse untill our password is long enough;
-		if ( fullword.length < this.options.minLength ) {
-			return this.getWords(1);
-		}
-		else {
-			//once we have enough words
-			fullword = this.join(this.words, this.stringToArray(this.options.separator));
-			return fullword;
-		}
+		//once we have enough words
+		fullword = this.join(this.words, this.stringToArray(this.options.separator));
+		return fullword;
 	};
 
 	/**

--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,7 @@ function CorrectHorseBatteryStaple() {
 	this.defaults = {
 		firstUpper:    true,
 		minWords:      4,
-		separator:     "-"
+		separator:     " "
 	};
 
 	/**
@@ -274,42 +274,10 @@ function CorrectHorseBatteryStaple() {
 		this.getRandomWords(numWords);
 
 		//generate a full string to test against min length
-		fullword = this.words.join(this.options.separator.substring(0, 1) || "");
+		fullword = this.words.join(this.options.separator);
 
-		//once we have enough words
-		fullword = this.join(this.words, this.stringToArray(this.options.separator));
 		return fullword;
 	};
-
-	/**
-	 * Join a set of words with random separators
-	 *
-	 * @param   {Array}    words       Array of words
-	 * @param   {Array}    separators
-	 * @returns {string}
-	 */
-	this.join = function(words, separators) {
-		var wordsLen,
-			i,
-			theString = "",
-			symbol = "";
-
-		wordsLen = words.length;
-
-		for ( i = 0; i < wordsLen; i++ ) {
-
-			if ( i !== wordsLen - 1 ) {
-				symbol = this.getSeparator(separators);
-			}
-			else {
-				symbol = "";
-			}
-
-			theString += words[i] + symbol;
-		}
-		return theString;
-	};
-
 
 	/**
 	 * Convert a string to an array of characters
@@ -333,18 +301,6 @@ function CorrectHorseBatteryStaple() {
 		}
 		return chars;
 	};
-
-
-	/**
-	 * Get a random separator from the separators array
-	 *
-	 * @param    {Array}    seps
-	 * @returns    {String}
-	 */
-	this.getSeparator = function(seps) {
-		return seps[ this.getUniformRandomInteger(0, seps.length) ] || "";
-	};
-
 
 	/**
 	 * Bind all UI related events


### PR DESCRIPTION
This removes a bunch of stuff that I don't think is necessary or even hurts security.
- Adding a number to the end just makes it harder to remember but only increases the security by 3.3 Bits
- Random separators are the same, they just make it harder to remember
- Less than 4 words is unreasonable from a security perspective. If nonetheless you want to use less, just use the first two or three words.
